### PR TITLE
Add CI: Go & Kustomize workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,11 @@ jobs:
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GITHUB_PATH v1.59.0
+          # $GITHUB_PATH is a file used by GitHub Actions to update the PATH.
+          # Don't pass it as a directory to the installer (that causes "File exists").
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${HOME}/bin" v1.59.0
+          # Add the install dir to PATH for subsequent steps
+          echo "${HOME}/bin" >> "$GITHUB_PATH"
 
       - name: Run go vet
         run: go vet ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,43 @@
+name: Go Build/Test/Lint
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    name: Build & Test & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ${{ github.workspace }}/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GITHUB_PATH v1.59.0
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run unit tests
+        run: go test ./... -v
+
+      - name: Run golangci-lint
+        run: golangci-lint run ./...

--- a/.github/workflows/kustomize.yml
+++ b/.github/workflows/kustomize.yml
@@ -1,0 +1,35 @@
+name: Kustomize Validate
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  validate:
+    name: Validate kustomize overlays
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install kustomize
+        run: |
+          KUSTOMIZE_VERSION=v5.0.1
+          curl -sSfL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar -xz -C /tmp
+          sudo mv /tmp/kustomize /usr/local/bin/
+
+      - name: Find kustomization.yaml files
+        run: |
+          echo "Searching for kustomization.yaml files..."
+          rg -n --hidden "kustomization.yaml$" || true
+
+      - name: Validate each kustomization
+        run: |
+          set -euo pipefail
+          while IFS= read -r file; do
+            dir=$(dirname "$file")
+            echo "Validating $dir"
+            kustomize build "$dir" >/dev/null
+          done < <(rg -n --hidden "kustomization.yaml$" -g '!vendor' -g '!.git' --no-line-number --files)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Direct build check:
 go build ./cmd/rubber-duck
 ```
 
+Install via `go install` (recommended for development):
+
+```bash
+# from the repository root
+go install ./cmd/rubber-duck
+# this will install the binary into $GOBIN or $GOPATH/bin
+```
+
+If you prefer to install a specific version from the repository remote once a tag is published:
+
+```bash
+go install github.com/Anddd7/rubber-duck/cmd/rubber-duck@latest
+```
+
 ## CLI quick usage
 
 ```bash
@@ -109,3 +123,10 @@ go run ./cmd/rubber-duck kust uninstall httpbin --overlay base -n default
 - `kust-patch install` requires `--pod` and patches the owning deployment.
 - `kust-patch uninstall` performs `rollout undo` (rollback), not restart.
 - Asset descriptions in CLI are read from each asset `README.md` first non-header line.
+
+CI
+
+This repository includes GitHub Actions workflows to validate changes automatically:
+
+- .github/workflows/go.yml — runs `go vet`, `go test`, and `golangci-lint` on push/PR
+- .github/workflows/kustomize.yml — builds each `kustomization` to validate templates


### PR DESCRIPTION
This PR adds GitHub Actions workflows:

- .github/workflows/go.yml — runs `go vet`, `go test`, and `golangci-lint` on push/PR
- .github/workflows/kustomize.yml — builds each kustomization to validate templates

Also updates README with `go install` instructions.

CI will run on push/PR to main/master.